### PR TITLE
bugfix/AOS-4571-check-if-health-textResponse-contains-status-property

### DIFF
--- a/src/screens/AffiliationViews/DeploymentView/DetailsView/InformationView/InformationViewNotifications.tsx
+++ b/src/screens/AffiliationViews/DeploymentView/DetailsView/InformationView/InformationViewNotifications.tsx
@@ -33,7 +33,8 @@ export const InformationViewNotifications = ({
   }
 
   const isInvalidImageReference =
-    !deployment.imageRepository?.isFullyQualified &&
+    deployment.imageRepository &&
+    !deployment.imageRepository.isFullyQualified &&
     deployment.details.deploymentSpec?.type === 'deploy';
 
   if (isMissingManagementInterface() || isInvalidImageReference) {

--- a/src/services/PodsStatusService.ts
+++ b/src/services/PodsStatusService.ts
@@ -83,36 +83,43 @@ export default class PodsStatusService {
       managementResponses.health &&
       managementResponses.health.textResponse
     ) {
-      const status = JSON.parse(managementResponses.health.textResponse).status;
-      switch (status) {
-        case 'UP':
-        case 'HEALTHY':
-          return {
-            icon: 'Completed',
-            color: STATUS_COLORS.healthy,
-          };
-        case 'COMMENT':
-        case 'OBSERVE':
-          return {
-            icon: 'Info',
-            color: STATUS_COLORS.observe,
-          };
-        case 'OUT_OF_SERVICE':
-        case 'DOWN':
-          return {
-            icon: 'Error',
-            color: STATUS_COLORS.down,
-          };
-        case 'OFF':
-          return {
-            icon: 'Blocked',
-            color: STATUS_COLORS.off,
-          };
-        default:
-          return {
-            icon: 'Info',
-            color: STATUS_COLORS.unknown,
-          };
+      if (
+        JSON.parse(managementResponses.health.textResponse).hasOwnProperty(
+          'status'
+        )
+      ) {
+        const status = JSON.parse(managementResponses.health.textResponse)
+          .status;
+        switch (status) {
+          case 'UP':
+          case 'HEALTHY':
+            return {
+              icon: 'Completed',
+              color: STATUS_COLORS.healthy,
+            };
+          case 'COMMENT':
+          case 'OBSERVE':
+            return {
+              icon: 'Info',
+              color: STATUS_COLORS.observe,
+            };
+          case 'OUT_OF_SERVICE':
+          case 'DOWN':
+            return {
+              icon: 'Error',
+              color: STATUS_COLORS.down,
+            };
+          case 'OFF':
+            return {
+              icon: 'Blocked',
+              color: STATUS_COLORS.off,
+            };
+          default:
+            return {
+              icon: 'Info',
+              color: STATUS_COLORS.unknown,
+            };
+        }
       }
     }
     return {


### PR DESCRIPTION
Denne PR'en fikser også en bug med isInvalidImageReference, hvor isInvalidImageReference kunne bli true dersom deployment.imageRepository var undefined.