### PR TITLE
bugfix/AOS-6033-deploy-feiler-dersom-man-redigerer-auroraconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2546,9 +2546,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.10.230",
-      "resolved": "https://nexus.sits.no/repository/npm-all/@microsoft/load-themed-styles/-/load-themed-styles-1.10.230.tgz",
-      "integrity": "sha512-EMc7AqUZxRnZTpnPasItHN5DXV/EdJ19wHyOls69PF089Ny9pUxZEbAPROOuR6I1m8WvNRJrlagLJgG9Yq0Y2w=="
+      "version": "1.10.233",
+      "resolved": "https://nexus.sits.no/repository/npm-all/@microsoft/load-themed-styles/-/load-themed-styles-1.10.233.tgz",
+      "integrity": "sha512-OSCpMTh1YmGpToiNbJv9lW95iZPebZEOafV/3bSefesAvYBUAJiJvhzO3l43hUD8MGiBc55JuVAjvIzqzg4eFg=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -2886,9 +2886,9 @@
       }
     },
     "@skatteetaten/frontend-components": {
-      "version": "4.2.0",
-      "resolved": "https://nexus.sits.no/repository/npm-all/@skatteetaten/frontend-components/-/frontend-components-4.2.0.tgz",
-      "integrity": "sha512-NiBXqDecYye6qsfuKdLuGbEzqIyBx1ZExErqjlu8DoJ6O5USVRsuPwxJ6y68Ht4KssX6yYc+CEp7vp+8bG+k1A==",
+      "version": "4.2.1",
+      "resolved": "https://nexus.sits.no/repository/npm-all/@skatteetaten/frontend-components/-/frontend-components-4.2.1.tgz",
+      "integrity": "sha512-5l5YBLG7nBezsm9ePZ3yHFoXLD0LpF4HQczRIBUm5ifWJGRj8OYjMD6EgLt6+jrqwtRbdxFwvKaGu/a11hrnGQ==",
       "requires": {
         "@fluentui/react": "7.153.2",
         "@uifabric/merge-styles": "7.19.1",
@@ -2898,7 +2898,6 @@
         "classnames": "2.2.6",
         "hotkeys-js": "3.8.1",
         "i18next": "20.3.1",
-        "material-design-icons": "3.0.1",
         "moment": "2.29.1",
         "node-fetch": "2.6.1",
         "prop-types": "15.7.2",
@@ -14136,11 +14135,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "material-design-icons": {
-      "version": "3.0.1",
-      "resolved": "https://nexus.sits.no/repository/npm-all/material-design-icons/-/material-design-icons-3.0.1.tgz",
-      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://nexus.sits.no/repository/npm-all/md5.js/-/md5.js-1.3.5.tgz",
@@ -15066,9 +15060,9 @@
       "dev": true
     },
     "office-ui-fabric-react": {
-      "version": "7.179.4",
-      "resolved": "https://nexus.sits.no/repository/npm-all/office-ui-fabric-react/-/office-ui-fabric-react-7.179.4.tgz",
-      "integrity": "sha512-e2UFt/OjFgh7Vvz+JjpyD5emWUHPt0ZiLHpIr96ZMr+nXBBkIUvG024IGm9LAppDvceCuR/ZBsZ3D31tStkDxA==",
+      "version": "7.180.0",
+      "resolved": "https://nexus.sits.no/repository/npm-all/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
+      "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
       "requires": {
         "@fluentui/date-time-utilities": "^7.9.1",
         "@fluentui/react-focus": "^7.18.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "1.6.2",
     "@skatteetaten/aurora-management-interface": "1.0.6",
-    "@skatteetaten/frontend-components": "4.2.0",
+    "@skatteetaten/frontend-components": "4.2.1",
     "cors": "2.8.5",
     "express": "4.17.1",
     "graphql": "16.0.1",

--- a/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.state.ts
+++ b/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.state.ts
@@ -1,13 +1,9 @@
 import { ImageTagType } from 'web/models/ImageTagType';
 import { VersionStatus } from '../../../models/VersionStatus';
 import { IImageTag } from 'web/services/auroraApiClients/imageRepositoryClient/query';
-import {
-  deploy,
-  refreshApplicationDeployment,
-} from 'web/store/state/applicationDeployments/action.creators';
+import { deploy } from 'web/store/state/applicationDeployments/action.creators';
 import { ReduxProps, RootState } from 'web/store/types';
 import { AuroraConfigFileResource } from 'web/services/auroraApiClients/applicationDeploymentClient/query';
-import { addCurrentErrors } from 'web/screens/ErrorHandler/state/actions';
 
 export interface IRedeployRowAndVersionTableProps {
   versionType: ImageTagType;
@@ -22,15 +18,12 @@ export interface IRedeployRowAndVersionTableProps {
 
 export const mapDispatchToProps = {
   deploy,
-  addCurrentErrors,
-  refreshApplicationDeployment,
 };
 
 export const mapStateToProps = ({ applications, versions }: RootState) => {
-  const { isDeploying, isRefreshing } = applications;
+  const { isDeploying } = applications;
   const { configuredVersionTag, isFetchingConfiguredVersionTag } = versions;
   return {
-    isRefreshing,
     isDeploying,
     configuredVersionTag,
     isFetchingConfiguredVersionTag,

--- a/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.state.ts
+++ b/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.state.ts
@@ -1,7 +1,10 @@
 import { ImageTagType } from 'web/models/ImageTagType';
 import { VersionStatus } from '../../../models/VersionStatus';
 import { IImageTag } from 'web/services/auroraApiClients/imageRepositoryClient/query';
-import { deploy } from 'web/store/state/applicationDeployments/action.creators';
+import {
+  deploy,
+  refreshApplicationDeployment,
+} from 'web/store/state/applicationDeployments/action.creators';
 import { ReduxProps, RootState } from 'web/store/types';
 import { AuroraConfigFileResource } from 'web/services/auroraApiClients/applicationDeploymentClient/query';
 import { addCurrentErrors } from 'web/screens/ErrorHandler/state/actions';
@@ -20,12 +23,14 @@ export interface IRedeployRowAndVersionTableProps {
 export const mapDispatchToProps = {
   deploy,
   addCurrentErrors,
+  refreshApplicationDeployment,
 };
 
 export const mapStateToProps = ({ applications, versions }: RootState) => {
-  const { isDeploying } = applications;
+  const { isDeploying, isRefreshing } = applications;
   const { configuredVersionTag, isFetchingConfiguredVersionTag } = versions;
   return {
+    isRefreshing,
     isDeploying,
     configuredVersionTag,
     isFetchingConfiguredVersionTag,

--- a/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.tsx
+++ b/src/web/screens/AffiliationViews/DeploymentView/DetailsView/VersionView/containers/RedeployRowAndVersionTable/RedeployRowAndVersionTable.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { AuroraConfigFileResource } from 'web/services/auroraApiClients/applicationDeploymentClient/query';
 import { RedeployRow } from '../../components/RedeployRow';
 import { VersionTableContainer } from '../VersionTable/VersionTableContainer';
 import {
   IRedeployRowAndVersionTableProps,
   IRedeployRowAndVersionTableState,
 } from './RedeployRowAndVersionTable.state';
-import YAML from 'yaml';
 
 type Props = IRedeployRowAndVersionTableProps &
   IRedeployRowAndVersionTableState;
@@ -19,75 +17,18 @@ export const RedeployRowAndVersionTable: React.FC<Props> = ({
   deployedVersion,
   versionType,
   deploy,
-  addCurrentErrors,
   isDeploying,
   releaseTo,
   isFetchingConfiguredVersionTag,
-  auroraConfigFiles,
   affiliation,
 }) => {
   const [versionBeingDeploy, setVersionBeingDeploy] = useState<
     string | undefined
   >();
 
-  function changeVersionInFile(
-    fileName: string,
-    fileContent: string,
-    version: string
-  ) {
-    if (fileName.endsWith('json')) {
-      const parsedApplicationFile: JSON = JSON.parse(fileContent);
-      return JSON.stringify(
-        { ...parsedApplicationFile, version: version },
-        null,
-        2
-      );
-    }
-    try {
-      const parsedApplicationFile = YAML.parseDocument(fileContent);
-      parsedApplicationFile.set('version', version);
-      return parsedApplicationFile.toString();
-    } catch {
-      addCurrentErrors({
-        errors: [
-          new Error(
-            `Could not parse the content of the application file. Make sure the file is of type yaml or json and does not contain syntax errors`
-          ),
-        ],
-        name: 'Parsing error',
-      });
-      return;
-    }
-  }
-
   const onConfirmDeploy = (version: string) => {
-    const applicationFile: AuroraConfigFileResource | undefined =
-      auroraConfigFiles.find((it) => it.type === 'APP');
-
-    if (!applicationFile) {
-      addCurrentErrors({
-        errors: [new Error(`An Application must have an application file`)],
-        name: 'Missing application file',
-      });
-      return;
-    }
-
-    const changedFile = changeVersionInFile(
-      applicationFile.name,
-      applicationFile.contents,
-      version
-    );
-
-    if (changedFile && hasAccessToDeploy) {
-      deploy(
-        {
-          auroraConfigName: affiliation,
-          contents: changedFile,
-          existingHash: applicationFile.contentHash,
-          fileName: applicationFile.name,
-        },
-        applicationId
-      );
+    if (hasAccessToDeploy) {
+      deploy(version, applicationId, affiliation);
       setVersionBeingDeploy(version);
     }
   };

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
@@ -1,0 +1,23 @@
+import YAML from 'yaml';
+
+export function changeVersionInFile(
+  fileName: string,
+  fileContent: string,
+  version: string
+) {
+  if (fileName.endsWith('json')) {
+    const parsedApplicationFile: JSON = JSON.parse(fileContent);
+    return JSON.stringify(
+      { ...parsedApplicationFile, version: version },
+      null,
+      2
+    );
+  }
+  try {
+    const parsedApplicationFile = YAML.parseDocument(fileContent);
+    parsedApplicationFile.set('version', version);
+    return parsedApplicationFile.toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/src/web/store/state/applicationDeployments/action.creators.ts
+++ b/src/web/store/state/applicationDeployments/action.creators.ts
@@ -1,7 +1,6 @@
 import { actions } from './actions';
 import { doAsyncActions } from 'web/utils/redux/action-utils';
 import { AsyncAction } from 'web/store/types';
-import { UpdateAuroraConfigFileInput } from 'web/services/auroraApiClients/applicationDeploymentClient/mutation';
 
 export function deleteAndRefreshApplications(
   affiliation: string,
@@ -23,8 +22,9 @@ export function deleteAndRefreshApplications(
   );
 }
 export function deploy(
-  updateAuroraConfigFileInput: UpdateAuroraConfigFileInput,
-  applicationDeploymentId: string
+  version: string,
+  applicationDeploymentId: string,
+  affiliation: string
 ) {
   return doAsyncActions(
     {
@@ -34,8 +34,9 @@ export function deploy(
     },
     (clients) =>
       clients.applicationDeploymentClient.updateAuroraConfigRedeployAndRefreshDeployment(
-        updateAuroraConfigFileInput,
-        applicationDeploymentId
+        applicationDeploymentId,
+        affiliation,
+        version
       )
   );
 }


### PR DESCRIPTION
Endte opp med å flytte mye av funksjonaliteten til applicationDeploymentClient, grunnet at den trenger å vite at den har fått refreshet og hentet AD før den tar og endrer på filene.

Eneste er at updateAuroraConfigRedeployAndRefreshDeployment funksjonen har fått en god del mer funksjonalitet og blitt litt større enn før.