### PR TITLE
bugfix/AOS-6082-applikasjon-uten-imageRepository-viser-missvisende-feilmelding

### DIFF
--- a/src/web/screens/AffiliationViews/DeploymentView/DetailsView/DetailsView.tsx
+++ b/src/web/screens/AffiliationViews/DeploymentView/DetailsView/DetailsView.tsx
@@ -48,9 +48,20 @@ function getVersionViewUnavailableMessage(
       'info'
     );
   }
-  if (!deployment.imageRepository?.isFullyQualified) {
+
+  if (
+    deployment.imageRepository &&
+    !deployment.imageRepository.isFullyQualified
+  ) {
     return serviceUnavailableBecause(
       'Applikasjonen har en Docker Image referanse som ikke går mot det interne Docker Registry, og versjoner kan dermed ikke hentes',
+      'warning'
+    );
+  }
+
+  if (!deployment.imageRepository) {
+    return serviceUnavailableBecause(
+      'Applikasjonen mangler image referanse. Dette kan bla. oppstå dersom applikasjonen er deployet med "type: development" og det er endret til "type: deploy" i applikasjonsfila. Løsningen er å deploye applikasjonen med ao slik at den får en image referanse.',
       'warning'
     );
   }


### PR DESCRIPTION
I tilfellene hvor imageRepository er undefined, så viser man i dagens konsoll en feilmelding som sier at applikasjonen bruker et annet docker registry. Denne endringen vil gi en bedre feilmelding med instrukser til å fikse problemet i de tilfellene hvor man ikke har et objekt for imageRepository.