### PR TITLE
bugfix/AOS-6217-Parsing-error-fra-ao-konsollet

### DIFF
--- a/src/web/services/auroraApiClients/applicationDeploymentClient/client.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/client.ts
@@ -65,13 +65,9 @@ export class ApplicationDeploymentClient {
       version
     );
 
-    if (!changedFile) {
+    if (changedFile instanceof Error) {
       return {
-        errors: [
-          new Error(
-            `Could not parse the content of the application file. Make sure the file is of type yaml or json and does not contain syntax errors`
-          ),
-        ],
+        errors: [changedFile],
         name: 'Parsing error',
       };
     }

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.test.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.test.ts
@@ -1,0 +1,48 @@
+import { changeVersionInFile } from './utils';
+
+describe('utils', () => {
+  it('empty json object should return json object with version', () => {
+    const changedFile = changeVersionInFile('env/app.json', '{}', '1');
+
+    expect(changedFile).toContain('"version": "1"');
+  });
+
+  it('yaml file with property baseFile should return yaml with baseFile and version', () => {
+    const changedFile = changeVersionInFile(
+      'env/app.yaml',
+      '---\nbaseFile: blabla\n',
+      'test-snapshot'
+    );
+
+    expect(changedFile).toContain('baseFile: blabla');
+    expect(changedFile).toContain('version: test-snapshot');
+  });
+
+  it('yaml file with only dashes should return yaml with version property', () => {
+    const changedFile = changeVersionInFile('env/app.yaml', '---\n', '1');
+
+    expect(changedFile).toContain('version: "1"');
+  });
+
+  it('empty yaml file should return yaml with version property', () => {
+    const changedFile = changeVersionInFile('env/app.yaml', '', '1');
+
+    expect(changedFile).toContain('version: "1"');
+  });
+
+  it('invalid yaml file should return undefined', () => {
+    const changedFile = changeVersionInFile(
+      'env/app.yaml',
+      '---\nbaseFile',
+      '1'
+    );
+
+    expect(changedFile).toEqual(undefined);
+  });
+
+  it('not supported file type should return undefined', () => {
+    const changedFile = changeVersionInFile('env/app.xml', '', '1');
+
+    expect(changedFile).toEqual(undefined);
+  });
+});

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.test.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.test.ts
@@ -7,42 +7,67 @@ describe('utils', () => {
     expect(changedFile).toContain('"version": "1"');
   });
 
-  it('yaml file with property baseFile should return yaml with baseFile and version', () => {
+  it('invalid json object should return error message', () => {
+    const changedFile = changeVersionInFile('env/app.json', '{version}', '1');
+
+    expect(changedFile).toEqual(
+      Error(
+        'Could not parse json in file=env/app.json Please check that the file contains valid json'
+      )
+    );
+  });
+
+  it('yaml file with property baseFile and comment should return yaml with baseFile, comment, and version', () => {
     const changedFile = changeVersionInFile(
       'env/app.yaml',
-      '---\nbaseFile: blabla\n',
+      '---\n#the baseFile used\nbaseFile: app.yaml\n',
       'test-snapshot'
     );
 
-    expect(changedFile).toContain('baseFile: blabla');
+    expect(changedFile).toContain('---');
+    expect(changedFile).toContain('#the baseFile used');
+    expect(changedFile).toContain('baseFile: app.yaml');
     expect(changedFile).toContain('version: test-snapshot');
   });
 
   it('yaml file with only dashes should return yaml with version property', () => {
     const changedFile = changeVersionInFile('env/app.yaml', '---\n', '1');
 
+    expect(changedFile).toContain('---');
     expect(changedFile).toContain('version: "1"');
   });
 
-  it('empty yaml file should return yaml with version property', () => {
+  it('empty yaml file should return error message', () => {
     const changedFile = changeVersionInFile('env/app.yaml', '', '1');
 
-    expect(changedFile).toContain('version: "1"');
+    expect(changedFile).toEqual(
+      Error(
+        'Could not parse yaml in file=env/app.yaml Please check that the file contains valid yaml'
+      )
+    );
   });
 
-  it('invalid yaml file should return undefined', () => {
+  it('invalid yaml file should return error message', () => {
     const changedFile = changeVersionInFile(
       'env/app.yaml',
       '---\nbaseFile',
       '1'
     );
 
-    expect(changedFile).toEqual(undefined);
+    expect(changedFile).toEqual(
+      Error(
+        'Could not parse yaml in file=env/app.yaml Please check that the file contains valid yaml'
+      )
+    );
   });
 
-  it('not supported file type should return undefined', () => {
+  it('not supported file type should return error message', () => {
     const changedFile = changeVersionInFile('env/app.xml', '', '1');
 
-    expect(changedFile).toEqual(undefined);
+    expect(changedFile).toEqual(
+      Error(
+        'Not supported file type used in file=env/app.xml Please check that the file is either yaml or json'
+      )
+    );
   });
 });

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
@@ -25,7 +25,7 @@ export function changeVersionInFile(
 function attemptFallbackMethod(fileContent: string, version: string) {
   try {
     let emptyYamlWithVersion = fileContent + `\nversion: ${version}`;
-    if (emptyYamlWithVersion.endsWith('\n')) {
+    if (fileContent.endsWith('\n')) {
       emptyYamlWithVersion = fileContent + `version: ${version}`;
     }
     return parseYaml(emptyYamlWithVersion, version);

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
@@ -16,26 +16,14 @@ export function changeVersionInFile(
     try {
       return parseYaml(fileContent, version);
     } catch {
-      return attemptFallbackMethod(fileContent, version);
+      return undefined;
     }
   }
   return undefined;
 }
 
-function attemptFallbackMethod(fileContent: string, version: string) {
-  try {
-    let emptyYamlWithVersion = fileContent + `\nversion: ${version}`;
-    if (fileContent.endsWith('\n')) {
-      emptyYamlWithVersion = fileContent + `version: ${version}`;
-    }
-    return parseYaml(emptyYamlWithVersion, version);
-  } catch {
-    return undefined;
-  }
-}
-
 function parseYaml(fileContent: string, version: string) {
-  const parsedApplicationFile = YAML.parseDocument(fileContent);
-  parsedApplicationFile.set('version', version);
-  return parsedApplicationFile.toString();
+  const parsedApplicationFile = YAML.parse(fileContent) ?? {};
+  parsedApplicationFile.version = version;
+  return YAML.stringify(parsedApplicationFile);
 }

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
@@ -12,12 +12,30 @@ export function changeVersionInFile(
       null,
       2
     );
+  } else if (fileName.endsWith('yaml')) {
+    try {
+      return parseYaml(fileContent, version);
+    } catch {
+      return attemptFallbackMethod(fileContent, version);
+    }
   }
+  return undefined;
+}
+
+function attemptFallbackMethod(fileContent: string, version: string) {
   try {
-    const parsedApplicationFile = YAML.parseDocument(fileContent);
-    parsedApplicationFile.set('version', version);
-    return parsedApplicationFile.toString();
+    let emptyYamlWithVersion = fileContent + `\nversion: ${version}`;
+    if (emptyYamlWithVersion.endsWith('\n')) {
+      emptyYamlWithVersion = fileContent + `version: ${version}`;
+    }
+    return parseYaml(emptyYamlWithVersion, version);
   } catch {
     return undefined;
   }
+}
+
+function parseYaml(fileContent: string, version: string) {
+  const parsedApplicationFile = YAML.parseDocument(fileContent);
+  parsedApplicationFile.set('version', version);
+  return parsedApplicationFile.toString();
 }

--- a/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
+++ b/src/web/services/auroraApiClients/applicationDeploymentClient/utils.ts
@@ -4,26 +4,47 @@ export function changeVersionInFile(
   fileName: string,
   fileContent: string,
   version: string
-) {
+): string | Error {
   if (fileName.endsWith('json')) {
-    const parsedApplicationFile: JSON = JSON.parse(fileContent);
-    return JSON.stringify(
-      { ...parsedApplicationFile, version: version },
-      null,
-      2
-    );
+    try {
+      return parseJson(fileContent, version);
+    } catch {
+      return new Error(
+        `Could not parse json in file=${fileName} Please check that the file contains valid json`
+      );
+    }
   } else if (fileName.endsWith('yaml')) {
     try {
       return parseYaml(fileContent, version);
     } catch {
-      return undefined;
+      return new Error(
+        `Could not parse yaml in file=${fileName} Please check that the file contains valid yaml`
+      );
     }
   }
-  return undefined;
+  return new Error(
+    `Not supported file type used in file=${fileName} Please check that the file is either yaml or json`
+  );
 }
+const isEmptyYaml = (content: string) => content.trim() === '---';
 
 function parseYaml(fileContent: string, version: string) {
-  const parsedApplicationFile = YAML.parse(fileContent) ?? {};
-  parsedApplicationFile.version = version;
-  return YAML.stringify(parsedApplicationFile);
+  if (isEmptyYaml(fileContent)) {
+    const emptyYaml = new YAML.Document({});
+    emptyYaml.directivesEndMarker = true;
+    emptyYaml.contents = { version };
+    return emptyYaml.toString();
+  }
+  const parsedApplicationFile = YAML.parseDocument(fileContent);
+  parsedApplicationFile.set('version', version);
+  return parsedApplicationFile.toString();
+}
+
+function parseJson(fileContent: string, version: string) {
+  const parsedApplicationFile: JSON = JSON.parse(fileContent);
+  return JSON.stringify(
+    { ...parsedApplicationFile, version: version },
+    null,
+    2
+  );
 }


### PR DESCRIPTION
- La til fallback metode som håndterer casene hvor yaml fila er tom eller kun inneholder dashes
- La til tester som sjekker forskjellige senarioer